### PR TITLE
fixed grammar in readme description

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![Angular](https://img.shields.io/badge/Angular-%3E%3D5.0-red.svg)
 ![npm](https://img.shields.io/npm/dm/angular5-csv.svg)
 
-> Helper library for create CSV file in Angular5
+> A helper library for creating CSV files in Angular5.
 > 
 
 ## Installation 


### PR DESCRIPTION
It looks like we'll also have to push this to the npmjs.com description as well if possible.