### PR TITLE
Remove unused peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,10 +63,5 @@
     "typescript": "^2.4.2",
     "webpack": "^3.4.1",
     "zone.js": "~0.7.2||~0.8.5"
-  },
-  "peerDependencies": {
-    "@angular/core": "^5.0.0",
-    "@angular/http": "^5.0.0",
-    "rxjs": "^5.5.2"
   }
 }


### PR DESCRIPTION
This fixes the complaints about it pinning to an outdated version of Angular, although with this change the name "angular5-csv" will make even less sense :P.